### PR TITLE
Add Conditionable to ActivityLogger

### DIFF
--- a/src/ActivityLogger.php
+++ b/src/ActivityLogger.php
@@ -9,12 +9,13 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
+use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\Macroable;
 use Spatie\Activitylog\Contracts\Activity as ActivityContract;
 
 class ActivityLogger
 {
-    use Macroable;
+    use Conditionable, Macroable;
 
     protected ?string $defaultLogName = null;
 


### PR DESCRIPTION
This PR adds `Conditionable` trait.

```
activity()
    ->by($comment->commented)
    ->on($comment->commentable)
    ->when(
        $condition,
        fn (ActivityLogger $logger) => $logger->chainSomething()
    )
    ->when(
        $anotherCondition,
        fn (ActivityLogger $logger) => $logger->chainSomethingElse()
    )
    ->log('comment.created');
```

The above would be a tidy implementation of something that could get more ugly as more conditions are added.